### PR TITLE
BUG: Fix endpoint for retrieving housing location details 

### DIFF
--- a/src/app/housing.service.ts
+++ b/src/app/housing.service.ts
@@ -15,8 +15,8 @@ export class HousingService {
     return (await data.json()) ?? [];
   }
 
-  async getHousingLocationById(id: number): Promise<HousingLocation> {
-    const data = await fetch(`${this.url}/?id=${id}`);
+  async getHousingLocationById(id: number): Promise<HousingLocation | undefined> {
+    const data = await fetch(`${this.url}/${id}`);
     return (await data.json()) ?? {};
   }
 


### PR DESCRIPTION
Bug causing component to render empty information due to invalid endpoint URL.

1. Using query params syntax: [url/?id=] returns a list of objects with id.
2. Using directly the syntax [url/id] returns the single object with specific id already unwrapped from the list.

Solution:
1. Keep same endpoint which returns the list of objects with specific id. The required change would be to return a list of HousingLocation objects as follows: `getHousingLocationById(...): Promise<HousingLocation[]>`.
2. Or change the endpoint to return single object with specific id and the return type would be a single HousingLocation object: `getHousingLocationById(...): Promise<HousingLocation>`.
